### PR TITLE
Added support for Counterpoise calculation in Gaussian with appropria…

### DIFF
--- a/ccinput/calculation.py
+++ b/ccinput/calculation.py
@@ -57,6 +57,7 @@ class Calculation:
         self.parameters = parameters
         self.type = type
         self.file = file
+        self.fragments = fragments
         if software not in SYN_SOFTWARE:
             raise InvalidParameter(f"Invalid software: '{software}'")
 

--- a/ccinput/calculation.py
+++ b/ccinput/calculation.py
@@ -50,13 +50,13 @@ class Calculation:
         software="",
         file=None,
         driver="none",
+        fragments=None,
         **kwargs,
     ):
         self.xyz = xyz
         self.parameters = parameters
         self.type = type
         self.file = file
-
         if software not in SYN_SOFTWARE:
             raise InvalidParameter(f"Invalid software: '{software}'")
 
@@ -105,7 +105,7 @@ class Calculation:
             raise InvalidParameter(
                 f"Multiplicity must at least 1 (received '{multiplicity}')"
             )
-
+            
         if parse_name:
             if not file:
                 raise InvalidParameter(

--- a/ccinput/packages/gaussian.py
+++ b/ccinput/packages/gaussian.py
@@ -65,7 +65,6 @@ class GaussianCalculation:
         self.confirmed_specifications = ""
         self.xyz_structure = ""
         self.input_file = ""
-        self.fragments = None
         if self.calc.type not in self.KEYWORDS:
             raise ImpossibleCalculation(
                 f"Gaussian 16 does not support calculations of type {self.calc.type}"
@@ -203,11 +202,8 @@ class GaussianCalculation:
         else:
             self.command_line += f"{method} "
         #Counterpoise related commands processing
-        if 'counterpoise' in self.commands.keys() or 'fragments' in self.commands.keys():
-            fragments_list = self.commands['fragments'][0].split(',')
-            check_fragments(self.commands['counterpoise'][0],fragments_list,self.calc.xyz)
-            self.fragments = fragments_list
-            del self.commands['fragments']
+        if 'counterpoise' in self.commands.keys() :
+            check_fragments(self.commands['counterpoise'][0],self.calc.fragments,self.calc.xyz)
 
     def parse_custom_basis_set(self, base_bs):
         custom_basis_sets = self.calc.parameters.custom_basis_sets
@@ -292,8 +288,10 @@ class GaussianCalculation:
     def handle_xyz(self):
         lines = [i + "\n" for i in clean_xyz(self.calc.xyz).split("\n") if i != ""]
         #If counterpoise correction is the option, modify xyz corresponding to fragments
-        if self.fragments != None:
-            lines = add_fragments_xyz(lines,self.fragments)
+        if self.calc.fragments != None :
+            print(self.calc.fragments)
+            print(type(self.calc.fragments))
+            lines = add_fragments_xyz(lines,self.calc.fragments)
         self.xyz_structure = "".join(lines)
 
     def parse_custom_solvation_radii(self):
@@ -409,9 +407,6 @@ class GaussianCalculation:
                         )
                     else:
                         self.confirmed_specifications += confirmed_spec
-            # Counterpoise specification special treatment
-            if cmd == 'counterpoise' :
-                cmd_formatted = f"{cmd}={option_str} "
 
             # This ensures that the command line follows this pattern:
             # CMD1 <CMD2> METHOD/BASIS_SET <ADDITIONAL_OPTION1> ...

--- a/ccinput/tests/test_gaussian.py
+++ b/ccinput/tests/test_gaussian.py
@@ -3782,7 +3782,8 @@ class GaussianTests(InputTests):
 
         with self.assertRaises(ImpossibleCalculation):
             self.generate_calculation(**params)
-    def test_sp_HF_CP_catch_Err1(self):
+
+    def test_sp_HF_CP_wrong_fragments(self):
         params = {
             "nproc": 8,
             "mem": "10000MB",
@@ -3792,17 +3793,14 @@ class GaussianTests(InputTests):
             "method": "HF",
             "basis_set": "3-21G",
             "charge": "0",
-            "specifications" : "counterpoise=2 fragments=1,1,1,1,2,2,2,2,2,5"
+            "specifications" : "counterpoise=2",
+            "fragments" : "1,1,1,1,2,2,2,2,2,5"
         }
-
-        REF = """
-        !!! You must assign exactly one fragment to each atom !!!
-        """
 
         with self.assertRaises(InvalidParameter):
             self.generate_calculation(**params)
     
-    def test_sp_HF_PCM_Bondi_CP(self):
+    def test_sp_HF_CP_1(self):
         params = {
             "nproc": 8,
             "mem": "10000MB",
@@ -3812,10 +3810,8 @@ class GaussianTests(InputTests):
             "method": "HF",
             "basis_set": "3-21G",
             "charge": "0",
-            "solvent": "chloroform",
-            "solvation_model": "PCM",
-            "solvation_radii": "Bondi",
-            "specifications" : "counterpoise=4 fragments=1,1,2,2,2,3,4,4,4",
+            "specifications" : "counterpoise=4 ",
+            "fragments" : "1,1,2,2,2,3,4,4,4"
         }
 
         inp = self.generate_calculation(**params)
@@ -3824,7 +3820,7 @@ class GaussianTests(InputTests):
         %chk=ethanol.chk
         %nproc=8
         %mem=10000MB
-        #p sp HF/3-21G counterpoise=4 SCRF(PCM, Solvent=chloroform, Read)
+        #p sp HF/3-21G counterpoise(4)
 
         File created by ccinput
 
@@ -3839,15 +3835,11 @@ class GaussianTests(InputTests):
         O(Fragment=4) 0.62360000 0.07990000 1.25870000
         H(Fragment=4) 0.94410000 0.53240000 2.04240000
 
-        Radii=bondi
-
-
-
         """
 
         self.assertTrue(self.is_equivalent(REF, inp.input_file))
     
-    def test_sp_HF_CP(self):
+    def test_sp_HF_CP_2(self):
         params = {
             "nproc": 8,
             "mem": "10000MB",
@@ -3857,7 +3849,8 @@ class GaussianTests(InputTests):
             "method": "HF",
             "basis_set": "3-21G",
             "charge": "0",
-            "specifications" : "counterpoise=2 fragments=1,1,1,1,2,2,2,2,2"
+            "specifications" : "counterpoise=2",
+            "fragments" : "1,1,1,1,2,2,2,2,2"
         }
 
         inp = self.generate_calculation(**params)
@@ -3866,7 +3859,7 @@ class GaussianTests(InputTests):
         %chk=ethanol.chk
         %nproc=8
         %mem=10000MB
-        #p sp HF/3-21G counterpoise=2
+        #p sp HF/3-21G counterpoise(2)
 
         File created by ccinput
 
@@ -3886,7 +3879,7 @@ class GaussianTests(InputTests):
 
         self.assertTrue(self.is_equivalent(REF, inp.input_file))
 
-    def test_sp_HF_PCM_Bondi_CP_Err2(self):
+    def test_sp_HF_CP_wrong_num_frag(self):
         params = {
             "nproc": 8,
             "mem": "10000MB",
@@ -3896,20 +3889,14 @@ class GaussianTests(InputTests):
             "method": "HF",
             "basis_set": "3-21G",
             "charge": "0",
-            "solvent": "chloroform",
-            "solvation_model": "PCM",
-            "solvation_radii": "Bondi",
-            "specifications" : "counterpoise=3 fragments=1,2,3,3,3,4,5,5,5",
+            "specifications" : "counterpoise=3",
+             "fragments" : "1,2,3,3,3,4,5,5,5",
         }
-
-        REF = """
-        !!! Counterpoise keyword must be equal to the total number of fragments !!!
-        """
 
         with self.assertRaises(InvalidParameter):
             self.generate_calculation(**params)
 
-    def test_sp_HF_CP_Err3(self):
+    def test_sp_HF_CP_wrong_start_num(self):
         params = {
             "nproc": 8,
             "mem": "10000MB",
@@ -3919,12 +3906,9 @@ class GaussianTests(InputTests):
             "method": "HF",
             "basis_set": "3-21G",
             "charge": "0",
-            "specifications" : "counterpoise=3 fragments=2,2,2,2,2,3,3,3,4"
+            "specifications" : "counterpoise=3 ",
+            "fragments" : "2,2,2,2,2,3,3,3,4"
         }
-
-        REF = """
-        !!! Fragment numbers must start from 1 !!!
-        """
 
         with self.assertRaises(InvalidParameter):
             self.generate_calculation(**params)

--- a/ccinput/tests/test_gaussian.py
+++ b/ccinput/tests/test_gaussian.py
@@ -3782,3 +3782,149 @@ class GaussianTests(InputTests):
 
         with self.assertRaises(ImpossibleCalculation):
             self.generate_calculation(**params)
+    def test_sp_HF_CP_catch_Err1(self):
+        params = {
+            "nproc": 8,
+            "mem": "10000MB",
+            "type": "Single-Point Energy",
+            "file": "ethanol.xyz",
+            "software": "Gaussian",
+            "method": "HF",
+            "basis_set": "3-21G",
+            "charge": "0",
+            "specifications" : "counterpoise=2 fragments=1,1,1,1,2,2,2,2,2,5"
+        }
+
+        REF = """
+        !!! You must assign exactly one fragment to each atom !!!
+        """
+
+        with self.assertRaises(InvalidParameter):
+            self.generate_calculation(**params)
+    
+    def test_sp_HF_PCM_Bondi_CP(self):
+        params = {
+            "nproc": 8,
+            "mem": "10000MB",
+            "type": "Single-Point Energy",
+            "file": "ethanol.xyz",
+            "software": "Gaussian",
+            "method": "HF",
+            "basis_set": "3-21G",
+            "charge": "0",
+            "solvent": "chloroform",
+            "solvation_model": "PCM",
+            "solvation_radii": "Bondi",
+            "specifications" : "counterpoise=4 fragments=1,1,2,2,2,3,4,4,4",
+        }
+
+        inp = self.generate_calculation(**params)
+
+        REF = """
+        %chk=ethanol.chk
+        %nproc=8
+        %mem=10000MB
+        #p sp HF/3-21G counterpoise=4 SCRF(PCM, Solvent=chloroform, Read)
+
+        File created by ccinput
+
+        0 1
+        C(Fragment=1) -1.31970000 -0.64380000 0.00000000
+        H(Fragment=1) -0.96310000 -1.65260000 0.00000000
+        H(Fragment=2) -0.96310000 -0.13940000 -0.87370000
+        H(Fragment=2) -2.38970000 -0.64380000 0.00000000
+        C(Fragment=2) -0.80640000 0.08220000 1.25740000
+        H(Fragment=3) -1.16150000 1.09160000 1.25640000
+        H(Fragment=4) -1.16470000 -0.42110000 2.13110000
+        O(Fragment=4) 0.62360000 0.07990000 1.25870000
+        H(Fragment=4) 0.94410000 0.53240000 2.04240000
+
+        Radii=bondi
+
+
+
+        """
+
+        self.assertTrue(self.is_equivalent(REF, inp.input_file))
+    
+    def test_sp_HF_CP(self):
+        params = {
+            "nproc": 8,
+            "mem": "10000MB",
+            "type": "Single-Point Energy",
+            "file": "ethanol.xyz",
+            "software": "Gaussian",
+            "method": "HF",
+            "basis_set": "3-21G",
+            "charge": "0",
+            "specifications" : "counterpoise=2 fragments=1,1,1,1,2,2,2,2,2"
+        }
+
+        inp = self.generate_calculation(**params)
+
+        REF = """
+        %chk=ethanol.chk
+        %nproc=8
+        %mem=10000MB
+        #p sp HF/3-21G counterpoise=2
+
+        File created by ccinput
+
+        0 1
+        C(Fragment=1) -1.31970000 -0.64380000 0.00000000
+        H(Fragment=1) -0.96310000 -1.65260000 0.00000000
+        H(Fragment=1) -0.96310000 -0.13940000 -0.87370000
+        H(Fragment=1) -2.38970000 -0.64380000 0.00000000
+        C(Fragment=2) -0.80640000 0.08220000 1.25740000
+        H(Fragment=2) -1.16150000 1.09160000 1.25640000
+        H(Fragment=2) -1.16470000 -0.42110000 2.13110000
+        O(Fragment=2) 0.62360000 0.07990000 1.25870000
+        H(Fragment=2) 0.94410000 0.53240000 2.04240000
+
+
+        """
+
+        self.assertTrue(self.is_equivalent(REF, inp.input_file))
+
+    def test_sp_HF_PCM_Bondi_CP_Err2(self):
+        params = {
+            "nproc": 8,
+            "mem": "10000MB",
+            "type": "Single-Point Energy",
+            "file": "ethanol.xyz",
+            "software": "Gaussian",
+            "method": "HF",
+            "basis_set": "3-21G",
+            "charge": "0",
+            "solvent": "chloroform",
+            "solvation_model": "PCM",
+            "solvation_radii": "Bondi",
+            "specifications" : "counterpoise=3 fragments=1,2,3,3,3,4,5,5,5",
+        }
+
+        REF = """
+        !!! Counterpoise keyword must be equal to the total number of fragments !!!
+        """
+
+        with self.assertRaises(InvalidParameter):
+            self.generate_calculation(**params)
+
+    def test_sp_HF_CP_Err3(self):
+        params = {
+            "nproc": 8,
+            "mem": "10000MB",
+            "type": "Single-Point Energy",
+            "file": "ethanol.xyz",
+            "software": "Gaussian",
+            "method": "HF",
+            "basis_set": "3-21G",
+            "charge": "0",
+            "specifications" : "counterpoise=3 fragments=2,2,2,2,2,3,3,3,4"
+        }
+
+        REF = """
+        !!! Fragment numbers must start from 1 !!!
+        """
+
+        with self.assertRaises(InvalidParameter):
+            self.generate_calculation(**params)

--- a/ccinput/utilities.py
+++ b/ccinput/utilities.py
@@ -421,3 +421,23 @@ def get_charge_mult_from_name(name):
         mult = 1
 
     return charge, mult
+def add_fragments_xyz(xyz,frag):
+    "Add fragment information to xyz"
+    xyz_frag = []
+    for i,line in enumerate(xyz):
+        line_splitted = line.split()
+        xyz_frag.append(f"{line_splitted[0]}(Fragment={frag[i]}) {line_splitted[1]} {line_splitted[2]} {line_splitted[3]} \n")
+    return xyz_frag
+def check_fragments(counterpoise,fragments,xyz):
+    """Checks if the fragments are reasonably defined"""
+    try:
+        fragments = [eval(i) for i in fragments]
+    except:
+        raise InvalidParameter("Fragment numbers must be integers")
+    unique_fragemnts = list(set(fragments))
+    if len([i + "\n" for i in clean_xyz(xyz).split("\n") if i != ""]) != len(fragments) :
+        raise InvalidParameter("You must assign exactly one fragment to each atom")
+    elif (sorted(unique_fragemnts) != list(range(1,max(unique_fragemnts)+1))):
+        raise InvalidParameter("Fragment numbers must start from 1")
+    elif ( len(unique_fragemnts) != int(counterpoise) ) :
+        raise InvalidParameter("Counterpoise keyword must be equal to the total number of fragments")

--- a/ccinput/utilities.py
+++ b/ccinput/utilities.py
@@ -424,20 +424,22 @@ def get_charge_mult_from_name(name):
 def add_fragments_xyz(xyz,frag):
     "Add fragment information to xyz"
     xyz_frag = []
+    frag = frag.split(',')
     for i,line in enumerate(xyz):
         line_splitted = line.split()
         xyz_frag.append(f"{line_splitted[0]}(Fragment={frag[i]}) {line_splitted[1]} {line_splitted[2]} {line_splitted[3]} \n")
     return xyz_frag
 def check_fragments(counterpoise,fragments,xyz):
     """Checks if the fragments are reasonably defined"""
+    fragments = fragments.split(',')
     try:
-        fragments = [eval(i) for i in fragments]
+        fragments = [int(i) for i in fragments]
     except:
         raise InvalidParameter("Fragment numbers must be integers")
-    unique_fragemnts = list(set(fragments))
+    unique_fragments = list(set(fragments))
     if len([i + "\n" for i in clean_xyz(xyz).split("\n") if i != ""]) != len(fragments) :
         raise InvalidParameter("You must assign exactly one fragment to each atom")
-    elif (sorted(unique_fragemnts) != list(range(1,max(unique_fragemnts)+1))):
+    elif (sorted(unique_fragments) != list(range(1,max(unique_fragments)+1))):
         raise InvalidParameter("Fragment numbers must start from 1")
-    elif ( len(unique_fragemnts) != int(counterpoise) ) :
+    elif ( len(unique_fragments) != int(counterpoise) ) :
         raise InvalidParameter("Counterpoise keyword must be equal to the total number of fragments")

--- a/ccinput/wrapper.py
+++ b/ccinput/wrapper.py
@@ -84,6 +84,7 @@ def generate_calculation(
     file=None,
     driver="none",
     trust_me=False,
+    fragments=None,
     **kwargs,
 ):
     if software is None:
@@ -148,6 +149,7 @@ def generate_calculation(
         file=file,
         driver=driver,
         **kwargs,
+        fragments=fragments
     )
 
     return process_calculation(calc)
@@ -418,6 +420,12 @@ def get_parser():
     parser.add_argument(
         "--version", "-v", action="version", version=f"%(prog)s {__version__}"
     )
+    parser.add_argument(
+        "--fragments",
+        dest="fragments",
+        default=None,
+        help="Assign each atom to a fragment",
+    )
     return parser
 
 
@@ -538,6 +546,7 @@ def get_input_from_args(args, default_params=None):
         "aux_name": args.aux_name,
         "header": args.header,
         "driver": args.driver,
+        "fragments": args.fragments,
     }
 
     if args.preset:


### PR DESCRIPTION
The input files with the counterpoise correction keyword and fragments can now be created.
The syntax is the following:
`... --specifications "counterpoise = N fragments = list_of_numbers" ...`
The _N_ is the number of fragments in the structure, and the _list of numbers_ assigns a fragment to each atom, in the same order as they are in the XYZ file.
The code will not allow unreasonable combinations of those two parameters (at least some of them).
The 5 appropriate tests are also added.
I could not run `python setup.py test` because this version of the file is not compatible with python 3.10+ (the collectible module is moved to another module or something like that). Nevertheless, I run every group test manually and they all passed.
I hope this addition is useful.
PS This is my first time contributing to any project, so please check it carefully if you can because I might have messed up something that I am not aware of.