### PR TITLE
Fix get_abs_basis_set when basis set is unknown and trust_me is True

### DIFF
--- a/ccinput/utilities.py
+++ b/ccinput/utilities.py
@@ -222,8 +222,8 @@ def get_abs_basis_set(basis_set, trust_me=False):
         if _bs.lower() == bs:
             return bs
     if trust_me:
-        warn(f"Using unknown basis set '{bs}'")
-        return bs
+        warn(f"Using unknown basis set '{basis_set}'")
+        return basis_set
     else:
         raise InvalidParameter(f"Unknown basis set: '{basis_set}'")
 


### PR DESCRIPTION
Fixes a bug in utilities.get_abs_basis_set() that returned the last element of BASIS_SET_EXCHANGE_KEY, picked up from the preceding for loop, if basis_set is unknown and trust_me is True.
